### PR TITLE
enable screen reader on character count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiptap-editor",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "description": "custom setup for the tiptap editor",
     "repository": "https://github.com/mirusresearch/tiptap-editor",
     "bugs": {

--- a/src/tiptap-editor.vue
+++ b/src/tiptap-editor.vue
@@ -77,6 +77,7 @@
             v-if="maxCharacterCount"
             :class="{ over: maxCharacterCountExceeded }"
             class="character-count"
+            aria-live="assertive"
         >
             {{ charactersRemaining }} characters remaining
         </div>


### PR DESCRIPTION
get screen reader to read out the character count in the text editor for mxeditor.
This issue is related to https://gitlab.mirus.io/root/statefarm/mysfdomain-ui/-/issues/410