### PR TITLE
A11Y tweaks

### DIFF
--- a/src/tiptap-editor.vue
+++ b/src/tiptap-editor.vue
@@ -227,12 +227,12 @@ export default {
                     },
                     onKeyDown: ({ event }) => {
                         // pressing up arrow
-                        if (event.keyCode === 38) {
+                        if (event.keyCode === 38 && this.currentOptions !== null) {
                             this.upHandler();
                             return true;
                         }
                         // pressing down arrow
-                        if (event.keyCode === 40) {
+                        if (event.keyCode === 40 && this.currentOptions !== null) {
                             this.downHandler();
                             return true;
                         }
@@ -240,6 +240,16 @@ export default {
                         if (event.keyCode === 13) {
                             return this.enterHandler();
                         }
+
+                        // pressing escape
+                        if (event.keyCode === 27) {
+                            this.navigatedOptionIndex = 0;
+                            this.optionRange = null;
+                            this.currentOptions = null;
+                            this.destroyPopup();
+                            return true;
+                        }
+
                         return false;
                     },
                 }),

--- a/src/tiptap-editor.vue
+++ b/src/tiptap-editor.vue
@@ -393,6 +393,10 @@ export default {
                 background-color: #f0f0f0;
             }
 
+            &:focus {
+                outline: 2px solid black;
+            }
+
             svg {
                 padding-top: 4px;
                 width: 12px;

--- a/src/tiptap-editor.vue
+++ b/src/tiptap-editor.vue
@@ -401,10 +401,11 @@ export default {
             &.is-active,
             &:hover {
                 background-color: #f0f0f0;
+                outline: 1px solid black;
             }
 
             &:focus {
-                outline: 2px solid black;
+                outline: 2px solid #0078d0;
             }
 
             svg {

--- a/src/tiptap-editor.vue
+++ b/src/tiptap-editor.vue
@@ -398,13 +398,14 @@ export default {
             width: 35px;
             vertical-align: bottom;
 
-            &.is-active,
-            &:hover {
+            &.is-active {
                 background-color: #f0f0f0;
                 outline: 1px solid black;
             }
 
-            &:focus {
+            &:focus,
+            &:hover {
+                background-color: #f0f0f0;
                 outline: 2px solid #0078d0;
             }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8620042/203398636-8738dac4-6740-42e8-a226-a324d96b6a1a.png)

- black outline to active header buttons, the slight gray alone is hard to see _for me_
- blue outline to focused header buttons. since this isnt explicitly defined, I think some browsers/os's aren't providing any border. 
- allow escape from popups

@Swinejamin thoughts