### PR TITLE
Check the index of all matching errors

### DIFF
--- a/dist/tiptap-editor.mjs
+++ b/dist/tiptap-editor.mjs
@@ -21962,8 +21962,11 @@ function Ow(t, e, n, r, i) {
     if (f.isText) {
       let d;
       for (; d = a.exec(f.text); ) {
-        const h = o.find((v) => v.value === d[0]), m = p + d.index;
-        h.offset && h.length ? m - 1 == h.offset && u(m, m + d[0].length, d[0]) : u(m, m + d[0].length, d[0]);
+        const h = o.filter((y) => y.value === d[0]), m = p + d.index;
+        let v = !1;
+        h.forEach((y) => {
+          y.offset && y.length && (v = !0, m - 1 === y.offset && u(m, m + d[0].length, d[0]));
+        }), v || u(m, m + d[0].length, d[0]);
       }
     }
   }), { highlights: l, on: c };

--- a/src/warnings.js
+++ b/src/warnings.js
@@ -64,15 +64,18 @@ function lint(doc, position, prev, getErrorWords, getInitialCharacterCount) {
             // Scan text nodes for bad words
             let m;
             while ((m = badWordsRegex.exec(node.text))) {
-                const originalErrorWord = words.find((word) => word.value === m[0]);
-
-                // highlight specific instance if the error has offset data
+                const matchingErrorWords = words.filter((word) => word.value === m[0]);
                 const indexOfMatchedWord = pos + m.index;
-                if (originalErrorWord.offset && originalErrorWord.length) {
-                    if (indexOfMatchedWord - 1 == originalErrorWord.offset) {
-                        record(indexOfMatchedWord, indexOfMatchedWord + m[0].length, m[0]);
+                let errorHasOffsetData = false;
+                matchingErrorWords.forEach((word) => {
+                    if (word.offset && word.length) {
+                        errorHasOffsetData = true;
+                        if (indexOfMatchedWord - 1 === word.offset) {
+                            record(indexOfMatchedWord, indexOfMatchedWord + m[0].length, m[0]);
+                        }
                     }
-                } else {
+                });
+                if (!errorHasOffsetData) {
                     record(indexOfMatchedWord, indexOfMatchedWord + m[0].length, m[0]);
                 }
             }


### PR DESCRIPTION
Iterate over the list of all errors that match the value of the error word, and see if the offset data matches the error word's offset data. Allows for multiple instances of the same error word, each with offset data given.